### PR TITLE
Make ADT macros to function partial, because in reality it is

### DIFF
--- a/adt-macros/shared/src/main/scala/japgolly/microlibs/adt_macros/AdtMacros.scala
+++ b/adt-macros/shared/src/main/scala/japgolly/microlibs/adt_macros/AdtMacros.scala
@@ -7,7 +7,7 @@ import AdtMacros.{AdtIso, AdtIsoSet}
 
 object AdtMacros {
 
-  type AdtIso[Adt, T] = (Adt => T, T => Adt, NonEmptyVector[Adt], NonEmptyVector[T])
+  type AdtIso[Adt, T] = (Adt => T, PartialFunction[T, Adt], NonEmptyVector[Adt], NonEmptyVector[T])
   def adtIso[Adt, T](f: Adt => T): AdtIso[Adt, T] = macro AdtMacros.quietAdtIso[Adt, T]
   def _adtIso[Adt, T](f: Adt => T): AdtIso[Adt, T] = macro AdtMacros.debugAdtIso[Adt, T]
 
@@ -70,7 +70,7 @@ class AdtMacros(val c: blackbox.Context) extends MacroUtils with JapgollyAccess 
 
     val impl = q"""
       val from: $Adt => $T = $f
-      val to: $T => $Adt = {case ..$toCases}
+      val to: PartialFunction[$T, $Adt] = {case ..$toCases}
       val adts = $SelectNonEmptyVector.varargs[$Adt](..$adtValues)
       val tos = $SelectNonEmptyVector.varargs[$T](..${fromFn.map(_._2)})
       assert(adts.length == tos.length)

--- a/adt-macros/shared/src/test/scala/japgolly/microlibs/adt_macros/AdtMacroTest.scala
+++ b/adt-macros/shared/src/test/scala/japgolly/microlibs/adt_macros/AdtMacroTest.scala
@@ -115,6 +115,8 @@ object AdtMacroTest extends TestSuite {
       assertUnorderedNEV(cs)('a', 'b', 'c')
       for (m <- ms)
         assert(cm(mc(m)) == m)
+
+      assert(cm.isDefinedAt('x') == false)  
     }
 
     'adtIsoSet {


### PR DESCRIPTION
Changes the `to` function in `AdtIso` from to a `PartialFunction`. I think this is closer to the truth, as we cannot prove the pattern matches back are exhaustive. Should be backwards compatible as PartialFunctions can always be called as functions.

What do you think?